### PR TITLE
Add feature attach filesystem to instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ If you haven't specified yc-token nor yc-service-account-key-file it will try to
 - `--yandex-use-internal-ip`: Use the internal Instance IP to communicate
 - `--yandex-userdata`: Path to file with cloud-init user-data
 - `--yandex-zone`: Yandex.Cloud zone
+- `--yandex-fs`: Filesystem to attach to the instance. Format 'deviceName=FilesystemID'
 
 #### Environment variables and default values
 
@@ -92,4 +93,5 @@ If you haven't specified yc-token nor yc-service-account-key-file it will try to
 | `--yandex-use-internal-ip` | YC_USE_INTERNAL_IP   | false                    |
 | `--yandex-userdata`        | YC_USERDATA          |                          |
 | `--yandex-zone`            | YC_ZONE              | ru-central1-a            |
+| `--yandex-fs`              | YC_FS                |                          |
 ---

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you haven't specified yc-token nor yc-service-account-key-file it will try to
 - `--yandex-use-internal-ip`: Use the internal Instance IP to communicate
 - `--yandex-userdata`: Path to file with cloud-init user-data
 - `--yandex-zone`: Yandex.Cloud zone
-- `--yandex-fs`: Filesystem to attach to the instance. Format 'deviceName=FilesystemID'
+- `--yandex-fs`: Filesystem to attach to the instance. Format 'mountPath=FilesystemID'
 
 #### Environment variables and default values
 

--- a/driver/client.go
+++ b/driver/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/docker/machine/libmachine/log"
@@ -141,10 +142,10 @@ func prepareInstanceCreateRequest(d *Driver, imageID string) *compute.CreateInst
 			log.Infof("Error in filesystem format %q", err)
 			request.FilesystemSpecs = fsSpecs
 		} else {
-			for deviceName, fileSystemId := range fs {
+			for deviceName, fileSystem := range fs {
 				fsSpecs = append(fsSpecs, &compute.AttachedFilesystemSpec{
 					DeviceName:   deviceName,
-					FilesystemId: fileSystemId,
+					FilesystemId: fileSystem["filesystemId"],
 					Mode:         compute.AttachedFilesystemSpec_READ_WRITE,
 				})
 			}

--- a/driver/client.go
+++ b/driver/client.go
@@ -135,16 +135,21 @@ func prepareInstanceCreateRequest(d *Driver, imageID string) *compute.CreateInst
 
 	if len(d.Filesystems) > 0 {
 		var fsSpecs []*compute.AttachedFilesystemSpec
-
-		for deviceName,fileSystemId := range d.ParseFilesystems(){
-			fsSpecs = append(fsSpecs, &compute.AttachedFilesystemSpec{
-				DeviceName:   deviceName,
-				FilesystemId: fileSystemId,
-				Mode: compute.AttachedFilesystemSpec_READ_WRITE,
-			})
+		fs, err := d.ParseFilesystems()
+		if err != nil {
+			//If error set empty Filesystems
+			log.Infof("Error in filesystem format %q", err)
+			request.FilesystemSpecs = fsSpecs
+		} else {
+			for deviceName, fileSystemId := range fs {
+				fsSpecs = append(fsSpecs, &compute.AttachedFilesystemSpec{
+					DeviceName:   deviceName,
+					FilesystemId: fileSystemId,
+					Mode:         compute.AttachedFilesystemSpec_READ_WRITE,
+				})
+			}
+			request.FilesystemSpecs = fsSpecs
 		}
-
-		request.FilesystemSpecs = fsSpecs
 	}
 
 	return request

--- a/driver/client.go
+++ b/driver/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/docker/machine/libmachine/log"

--- a/driver/client.go
+++ b/driver/client.go
@@ -133,6 +133,20 @@ func prepareInstanceCreateRequest(d *Driver, imageID string) *compute.CreateInst
 		}
 	}
 
+	if len(d.Filesystems) > 0 {
+		var fsSpecs []*compute.AttachedFilesystemSpec
+
+		for deviceName,fileSystemId := range d.ParseFilesystems(){
+			fsSpecs = append(fsSpecs, &compute.AttachedFilesystemSpec{
+				DeviceName:   deviceName,
+				FilesystemId: fileSystemId,
+				Mode: compute.AttachedFilesystemSpec_READ_WRITE,
+			})
+		}
+
+		request.FilesystemSpecs = fsSpecs
+	}
+
 	return request
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -55,7 +55,7 @@ type Driver struct {
 	StaticAddress    string
 	SecurityGroups   []string
 	ServiceAccountID string
-	Filesystems     []string
+	Filesystems      []string
 }
 
 const (
@@ -242,7 +242,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "YC_FS",
 			Name:   "yandex-fs",
 			Usage:  "Filesystem to attach to the instance. Format 'deviceName=FilesystemID'",
-			},
+		},
 	}
 }
 
@@ -580,14 +580,17 @@ func (d *Driver) ParsedLabels() map[string]string {
 	return labels
 }
 
-func (d *Driver) ParseFilesystems() map[string]string {
+func (d *Driver) ParseFilesystems() (map[string]string, error) {
 	var filesystems = make(map[string]string)
 	for _, fsPair := range d.Filesystems {
 		fsPair = strings.TrimSpace(fsPair)
 		chunks := strings.SplitN(fsPair, "=", 2)
+		if len(chunks) < 2 {
+			return filesystems, fmt.Errorf("wrong filesystem flag format. Need use format deviceName=FilesystemID. Example: --yandex-fs='sharefs=fs_id'")
+		}
 		filesystems[chunks[0]] = chunks[1]
 	}
-	return filesystems
+	return filesystems, nil
 }
 
 func (d *Driver) publicSSHKeyPath() string {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -55,6 +55,7 @@ type Driver struct {
 	StaticAddress    string
 	SecurityGroups   []string
 	ServiceAccountID string
+	Filesystems     []string
 }
 
 const (
@@ -237,6 +238,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "yandex-sa-id",
 			Usage:  "Service account ID to attach to the instance",
 		},
+		mcnflag.StringSliceFlag{
+			EnvVar: "YC_FS",
+			Name:   "yandex-fs",
+			Usage:  "Filesystem to attach to the instance. Format 'deviceName=FilesystemID'",
+			},
 	}
 }
 
@@ -269,6 +275,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.StaticAddress = flags.String("yandex-static-address")
 	d.SecurityGroups = flags.StringSlice("yandex-security-groups")
 	d.ServiceAccountID = flags.String("yandex-sa-id")
+	d.Filesystems = flags.StringSlice("yandex-fs")
 
 	return nil
 }
@@ -571,6 +578,16 @@ func (d *Driver) ParsedLabels() map[string]string {
 		}
 	}
 	return labels
+}
+
+func (d *Driver) ParseFilesystems() map[string]string {
+	var filesystems = make(map[string]string)
+	for _, fsPair := range d.Filesystems {
+		fsPair = strings.TrimSpace(fsPair)
+		chunks := strings.SplitN(fsPair, "=", 2)
+		filesystems[chunks[0]] = chunks[1]
+	}
+	return filesystems
 }
 
 func (d *Driver) publicSSHKeyPath() string {

--- a/driver/testdata/fs-user-data.golden
+++ b/driver/testdata/fs-user-data.golden
@@ -9,3 +9,9 @@ users:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDkai1XE7djYB5Z
 
 
+runcmd:
+
+  - mkdir /data
+  - mount -t virtiofs data /data
+
+

--- a/driver/testdata/user-data_from_file.golden
+++ b/driver/testdata/user-data_from_file.golden
@@ -15,6 +15,8 @@ users:
     ssh_authorized_keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDkai1XE7djYB5Z
 
+
+
 --DOCKERMACHINEMIMEBOUNDARY
 Content-Disposition: attachment; filename="docker-machine-yandex-driver.yaml"
 Content-Type: text/cloud-config


### PR DESCRIPTION
Позволяет добавить к ВМ filesystem.
Usecase:
- Общее хранилище для артефактов в динамичных gitlab-раннеров
- Общее хранилищее для докер-образов

Для автоматического подключения FS можно использовать meta-файл, примерно такого вида:

---

runcmd:
  - mkdir /data
  - mount -t virtiofs diveceName /data